### PR TITLE
fix: adjust border colors

### DIFF
--- a/themes/vague.json
+++ b/themes/vague.json
@@ -267,12 +267,12 @@
         "title_bar.background": "#141415",
         "toolbar.background": "#141415",
 
-        "border": "#878787",
-        "border.variant": "#252530",
+        "border": "#252530",
+        "border.variant": "#878787",
         "border.selected": "#6e94b2",
         "border.disabled": "#252530",
         "border.focused": "#405065",
-        "border.transparent": "#14141500",
+        "border.transparent": "#00000000",
 
         "terminal.ansi.black": "#252530",
         "terminal.ansi.bright_black": "#606079",


### PR DESCRIPTION
Use a less bright border color (see discussion in
https://github.com/vague-theme/vague.nvim/pull/59#discussion_r2265209191), which was reverted in 80af8a43a230824905c556cbd2aa8c70d4b6fce7.

Also adds the missing `border.variant`, so popups have a bright border while the rest of the interface remains subtle and non-distracting.