### PR TITLE
feat: define accent colors

### DIFF
--- a/themes/vague.json
+++ b/themes/vague.json
@@ -2,20 +2,20 @@
   "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
   "name": "Vague",
   "author": "Aejkatappaja, L1NC5 (original vim theme by vague2k)",
-  "accents": [
-    "#c48282",
-    "#e8b589",
-    "#e0a363",
-    "#c3c3d5",
-    "#aeaed1",
-    "#bb9bdb",
-    "#6e94b2"
-  ],
   "themes": [
     {
       "name": "Vague",
       "appearance": "dark",
       "style": {
+        "accents": [
+          "#7e98e8",
+          "#6e94b2",
+          "#7fa563",
+          "#e8b589",
+          "#c48282",
+          "#bb9bdb",
+          "#aeaed1"
+        ],
         "background": "#141415",
         "syntax": {
           "comment": {


### PR DESCRIPTION
Mainly used for rainbow indentation support
<img width="646" height="508" alt="image" src="https://github.com/user-attachments/assets/80f52b83-cfb7-4a4c-af08-6d47d5fc4e9c" />
<img width="204" height="623" alt="image" src="https://github.com/user-attachments/assets/cc0f0204-99c6-46af-a660-b352d3e88f35" />
