### PR TITLE
feat: border-color on panel focused elements

### DIFF
--- a/themes/vague.json
+++ b/themes/vague.json
@@ -256,7 +256,7 @@
 
         "elevated_surface.background": "#141415",
         "panel.background": "#141415",
-        "panel.focused_border": "#405065",
+        "panel.focused_border": "#6e94b2",
 
         "search.match_background": "#4050651a",
 


### PR DESCRIPTION
Before:
<img width="246" height="75" alt="• themes" src="https://github.com/user-attachments/assets/006b664b-f41b-4f00-97fa-89a1fe35e1e1" />

After:
<img width="248" height="139" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/19d75a92-263d-4cc2-91b8-9879ef56e1ea" />
<img width="251" height="95" alt="image" src="https://github.com/user-attachments/assets/92fed79b-bdfa-4e79-aeb0-b7217732f5ce" />

Not completely sure about the color here, as the neovim theme doesn't need to differentiate between focused and selected